### PR TITLE
Change references between primary and accent

### DIFF
--- a/scss/_bootstrap-overrides.scss
+++ b/scss/_bootstrap-overrides.scss
@@ -15,8 +15,9 @@ $theme-colors: () !default;
     $yellow:   #ffc107 !default;
     $red:      #dc3545 !default;
 
-    $accent: $blue !default;
-    $primary: $accent !default;
+    $primary: $blue !default;
+    $accent: $primary !default;
+   
     $secondary: #e4e7eb !default;
     $info: $cyan !default;
     $success: $green !default;


### PR DESCRIPTION
While trying to customize bootstrap theme had this setup in project folder.
root
   \node_modules
   \styles
        \_custom.scss
        \bootstrap.scss
        \kendo.all.scss
   \index.html

//_custom,scss
$primary: teal;

//bootstrap.scss
@import "custom";
@import "../node_modules/@progress/kendo-theme-bootstrap/modules/bootstrap/scss/bootstrap";

//kendo.all.scss
@import "custom";
@import "../node_modules/@progress/kendo-theme-bootstrap/scss/all";

//index.html
<link href="styles/bootstrap.css" rel="stylesheet" type="text/css" />
 <link href="styles/kendo.all.css" rel="stylesheet" type="text/css" />


Expected:
both .btn-primary and .k-button-primary have same (teal) background.
Actual:
only .btn-primary has teal background.